### PR TITLE
Replace nil with system variables for default config

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,20 @@ An Elixir client for the parse.com REST API
 
 2. Create environment files `config/prod.exs` (for production), `config/dev.exs` (for development) and `config/test.exs`
 
-3. Configure parse_client with your parse.com Application ID and API key 
+3. Configure parse_client with your parse.com Application ID and API key
 
+  Use system variables (preferred)
+  ```elixir    
+  # prod.exs
+
+  use Mix.Config
+
+  config :parse_client,
+    parse_application_id: System.get_env("PARSE_APPLICATION_ID"),
+    parse_api_key: System.get_env("PARSE_API_KEY")
+  ```
+
+  Or use them explicitly
   ```elixir    
   # prod.exs
 

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,5 +1,5 @@
 use Mix.Config
 
 config :parse_client,
-  parse_application_id: nil,
-  parse_api_key: nil
+  parse_application_id: System.get_env("PARSE_APPLICATION_ID"),
+  parse_api_key: System.get_env("PARSE_API_KEY")

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -1,5 +1,5 @@
 use Mix.Config
 
 config :parse_client,
-  parse_application_id: nil,
-  parse_api_key: nil
+  parse_application_id: System.get_env("PARSE_APPLICATION_ID"),
+  parse_api_key: System.get_env("PARSE_API_KEY")

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,5 +1,5 @@
 use Mix.Config
 
 config :parse_client,
-  parse_application_id: nil,
-  parse_api_key: nil
+  parse_application_id: System.get_env("PARSE_APPLICATION_ID"),
+  parse_api_key: System.get_env("PARSE_API_KEY")

--- a/test/config_test.exs
+++ b/test/config_test.exs
@@ -6,18 +6,17 @@ defmodule ParseClient.ConfigTest do
   test "returns parse_application_id" do
     Application.put_env(:parse_client, :parse_application_id, "123")
     assert config_parse_id == "123"
-
-    Application.put_env(:parse_client, :parse_application_id, nil)
   end
 
   test "returns parse_api_key" do
     Application.put_env(:parse_client, :parse_api_key, "456")
     assert config_parse_key == "456"
-
-    Application.put_env(:parse_client, :parse_api_key, nil)
   end
 
-  test "returns ArgumentError when environment variable is nil" do
+  test "returns ArgumentError when environment variables are not set" do
+    Application.put_env(:parse_client, :parse_api_key, nil)
+    Application.put_env(:parse_client, :parse_application_id, nil)
+
     assert_raise ArgumentError, "Authentication failed. Add API key and App ID to config files.", fn ->
       config_parse_id
     end


### PR DESCRIPTION
@riverrun reduces the chance a contributor will commit their api key / app id.  Provides the option to be implicit or explicit in declaring key / id in a project.
